### PR TITLE
fix: reorder sif alumni

### DIFF
--- a/_site/assets/js/mustache-fellows-render.js
+++ b/_site/assets/js/mustache-fellows-render.js
@@ -676,7 +676,7 @@ let coryView = {
 
 
 // Mustache render logic for individual page views | ?user="firstname-lastname"
-var fellowsArray = new Array(candisView, jacquelynView, melissaView, suzanneView, eliView, georgeView, razaView, raviView, indraView, lindsayView, aksharView, taylorView, priyaView, stacyView, kevinView, elizabethView, jayView, minhView, maryView, nathanielView, manujView, colleenView, loriView, kelseyView, samuelView, ronaView, nicholView, bethView, amandaView, michaelView, arashView, danielleView, coryView);
+var fellowsArray = new Array(suzanneView, eliView, georgeView, razaView, raviView, indraView, lindsayView, aksharView, taylorView, priyaView, stacyView, kevinView, elizabethView, jayView, minhView, nathanielView, manujView, samuelView, colleenView, loriView, kelseyView, bethView, amandaView, michaelView, arashView, danielleView, coryView, candisView, jacquelynView, melissaView, maryView, ronaView, nicholView);
 
 var tab;
 var img;

--- a/assets/js/mustache-fellows-render.js
+++ b/assets/js/mustache-fellows-render.js
@@ -676,7 +676,7 @@ let coryView = {
 
 
 // Mustache render logic for individual page views | ?user="firstname-lastname"
-var fellowsArray = new Array(candisView, jacquelynView, melissaView, suzanneView, eliView, georgeView, razaView, raviView, indraView, lindsayView, aksharView, taylorView, priyaView, stacyView, kevinView, elizabethView, jayView, minhView, maryView, nathanielView, manujView, colleenView, loriView, kelseyView, samuelView, ronaView, nicholView, bethView, amandaView, michaelView, arashView, danielleView, coryView);
+var fellowsArray = new Array(suzanneView, eliView, georgeView, razaView, raviView, indraView, lindsayView, aksharView, taylorView, priyaView, stacyView, kevinView, elizabethView, jayView, minhView, nathanielView, manujView, samuelView, colleenView, loriView, kelseyView, bethView, amandaView, michaelView, arashView, danielleView, coryView, candisView, jacquelynView, melissaView, maryView, ronaView, nicholView);
 
 var tab;
 var img;


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Feature
- [ ] Bug Fix
- [x] Hot Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
SIF alumni fellows out of order. Corrected: alpha, oldest to newest

## Related Tickets & Documents
- Monday Task https://blackberg-group.monday.com/boards/1931719392/pulses/7510398795

## QA Instructions, Screenshots, Recordings
make sure SIF alumni in alpha order, oldest to newest

### UI accessibility checklist
_If your PR includes UI changes, please utilize this checklist:_
- [ ] Semantic HTML implemented?
- [ ] Keyboard operability supported?
- [ ] Checked with [Google Lighthouse](https://developer.chrome.com/docs/lighthouse/overview) and addressed `Critical` and `Serious` issues?
- [ ] Color contrast tested?


## Are there any post deployment tasks we need to perform?
- Add GA code on production
- Proper meta tags utilized 

## Changed Files in this Pull Request ##
- _site/assets/js/mustache-fellows-render.js
 - assets/js/mustache-fellows-render.js